### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -2,7 +2,10 @@ version: 2.1
 
 description: >
   Send deployment notifications to the Honeybadger API
-  Repo: https://github.com/honeybadger-io/circleci-orb
+
+display:
+  home_url: https://www.honeybadger.io/
+  source_url: https://github.com/honeybadger-io/circleci-orb
 
 commands:
   notify_deploy:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.